### PR TITLE
feat: add process grouping by name

### DIFF
--- a/src/mcp_memory/models.py
+++ b/src/mcp_memory/models.py
@@ -32,6 +32,16 @@ class ProcessInfo(BaseModel):
     cmdline: str = Field(description="Command line (truncated)")
 
 
+class ProcessGroup(BaseModel):
+    """Aggregated information for processes with the same name."""
+
+    name: str = Field(description="Process name")
+    count: int = Field(description="Number of instances")
+    total_memory_mb: float = Field(description="Total memory usage in MB")
+    total_memory_percent: float = Field(description="Total memory usage percentage")
+    pids: list[int] = Field(description="List of process IDs")
+
+
 class KillResult(BaseModel):
     """Result of attempting to kill a single process."""
 

--- a/src/mcp_memory/server.py
+++ b/src/mcp_memory/server.py
@@ -2,11 +2,12 @@
 
 from fastmcp import FastMCP
 
-from mcp_memory.models import KillSummary, MemoryInfo, ProcessInfo
+from mcp_memory.models import KillSummary, MemoryInfo, ProcessGroup, ProcessInfo
 from mcp_memory.tools.kill import kill_processes as _kill_processes
 from mcp_memory.tools.memory import list_memory_usage as _list_memory_usage
 from mcp_memory.tools.processes import (
     find_stale_processes as _find_stale_processes,
+    list_process_groups as _list_process_groups,
     list_top_processes as _list_top_processes,
 )
 
@@ -17,6 +18,7 @@ mcp = FastMCP(
 Available tools:
 - list_memory_usage: Get system memory summary (like `free -h`)
 - list_top_processes: Find top memory/CPU consumers
+- list_process_groups: Aggregate processes by name with totals
 - find_stale_processes: Find old/idle processes by criteria
 - kill_processes: Terminate processes with safety checks
 """,
@@ -50,6 +52,27 @@ def list_top_processes(
         List of processes sorted by the specified criterion
     """
     return _list_top_processes(n=n, sort_by=sort_by)
+
+
+@mcp.tool()
+def list_process_groups(
+    n: int = 10,
+    min_count: int = 1,
+) -> list[ProcessGroup]:
+    """
+    List processes grouped by name with aggregated stats.
+
+    Useful for seeing total resource usage by process type
+    (e.g., "3 claude processes using 1.6GB total").
+
+    Args:
+        n: Number of groups to return (default 10, max 50)
+        min_count: Minimum number of instances to include (default 1)
+
+    Returns:
+        List of process groups sorted by total memory usage descending
+    """
+    return _list_process_groups(n=n, min_count=min_count)
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary
- Add `list_process_groups` tool to aggregate processes by name
- Shows count, total memory, and PIDs per group
- Sorted by total memory descending
- Supports `min_count` filter (e.g., only show names with 2+ instances)

Closes #6